### PR TITLE
Simplify Dockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is the PHP container for the Stowers in-house LIMS application.
 * intl
 * ldap
 * mcrypt
-* memcached
+* memcached 3.0.3
 * Opcache
 * PDO
   * MSSQL/SYBASE

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -57,7 +57,7 @@ RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
 RUN docker-php-ext-install -j$(nproc) mcrypt
 
 # Install php extension: memcached
-RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
+RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/v3.0.3.tar.gz" \
     && mkdir -p /usr/src/php/ext/memcached \
     && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \
     && docker-php-ext-configure memcached \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -8,85 +8,85 @@ ENV TERM dumb
 RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y \
+    # Included applications
     git \
     mysql-client \
     php-pear \
-    tree
+    tree \
+    vim \
+    # Needed for building extensions
+    # For gd
+    libpng-dev \
+    # For imap
+    libc-client-dev \ 
+    libkrb5-dev \
+    # For intl
+    libicu-dev \
+    # For ldap
+    libldap2-dev \
+    # For mcrypt
+    libmcrypt-dev \
+    # For memcached
+    libmemcached-dev \
+    # For PDO MSSQL/SYBASE
+    freetds-common \
+    freetds-dev \
+    # For zip
+    zlib1g-dev
 
-# Install needed php extension: imap
-RUN apt-get install -y \
-    libc-client-dev \
-    libkrb5-dev && \
-    docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
+# Clean up unneccessary package information
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get clean all
+
+# Install php extension: gd
+# Used by molbio to generate images and sparklines
+RUN docker-php-ext-install -j$(nproc) gd
+
+# Install php extension: imap
+RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install -j$(nproc) imap
 
-# Install needed php extension: intl
-RUN apt-get install -y \
-    libicu-dev && \
-    docker-php-ext-install -j$(nproc) intl
+# Install php extension: intl
+RUN docker-php-ext-install -j$(nproc) intl
 
-# Install needed php extension: ldap
-RUN apt-get install -y \
-    libldap2-dev && \
-    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+# Install php extension: ldap
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
     docker-php-ext-install -j$(nproc) ldap
 
-# Install needed php extension: mcrypt
-RUN apt-get install -y \
-    libmcrypt-dev && \
-    docker-php-ext-install -j$(nproc) mcrypt
+# Install php extension: mcrypt
+RUN docker-php-ext-install -j$(nproc) mcrypt
 
-# Install needed php extension: memcached
-RUN apt-get install -y \
-    libmemcached-dev && \
-    curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
+# Install php extension: memcached
+RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
     && mkdir -p /usr/src/php/ext/memcached \
     && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \
     && docker-php-ext-configure memcached \
     && docker-php-ext-install memcached \
     && rm /tmp/memcached.tar.gz
 
-# Install OCI-8
+# Install php extension: OCI-8
 # RUN docker-php-ext-install -j$(nproc) oci8
 
 # Enable Opcache
 RUN docker-php-ext-enable opcache
 
-# Install PDO
+# Install php extension: PDO
 RUN docker-php-ext-install -j$(nproc) pdo
 
-# Install PDO: MSSQL/SYBASE
-RUN apt-get install -y \
-    freetds-common \
-    freetds-dev && \
-    ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so && \
+# Install php extension: PDO: MSSQL/SYBASE
+RUN ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so && \
     ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a /usr/lib/libsybdb.a && \
     ldconfig -v && \
     docker-php-ext-install -j$(nproc) pdo_dblib
 
-# Install PDO: MySQL
+# Install php extension: PDO: MySQL
 RUN docker-php-ext-install -j$(nproc) pdo_mysql
 
-# Install mysqli (used by the legacy system)
+# Install php extension: mysqli (used by the legacy system)
 RUN docker-php-ext-install mysqli
 
-# Install needed php extension: zip
-RUN apt-get install -y \
-    zlib1g-dev && \
-    docker-php-ext-install -j$(nproc) zip
-
-# Install needed php extension: gd
-# Used by molbio to generate images and sparklines
-RUN apt-get install -y \
-    libpng-dev && \
-    docker-php-ext-install -j$(nproc) gd
-
-# Utility packages
-RUN apt-get install -y vim
-
-# Clean up unneccessary package information
-RUN rm -rf /var/lib/apt/lists/* && \
-    apt-get clean all
+# Install php extension: zip
+RUN docker-php-ext-install -j$(nproc) zip
 
 COPY resources/usr/local/etc/php/php.ini /usr/local/etc/php/
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -32,61 +32,63 @@ RUN apt-get install -y \
     freetds-common \
     freetds-dev \
     # For zip
-    zlib1g-dev
+    zlib1g-dev \
+    && \
 
 # Clean up unneccessary package information
-RUN rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* && \
     apt-get clean all
 
+RUN \
 # Install php extension: gd
 # Used by molbio to generate images and sparklines
-RUN docker-php-ext-install -j$(nproc) gd
+    docker-php-ext-install -j$(nproc) gd && \
 
 # Install php extension: imap
-RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
-    docker-php-ext-install -j$(nproc) imap
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
+    docker-php-ext-install -j$(nproc) imap && \
 
 # Install php extension: intl
-RUN docker-php-ext-install -j$(nproc) intl
+    docker-php-ext-install -j$(nproc) intl && \
 
 # Install php extension: ldap
-RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
-    docker-php-ext-install -j$(nproc) ldap
+    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+    docker-php-ext-install -j$(nproc) ldap && \
 
 # Install php extension: mcrypt
-RUN docker-php-ext-install -j$(nproc) mcrypt
+    docker-php-ext-install -j$(nproc) mcrypt && \
 
 # Install php extension: memcached
-RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/v3.0.3.tar.gz" \
-    && mkdir -p /usr/src/php/ext/memcached \
-    && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \
-    && docker-php-ext-configure memcached \
-    && docker-php-ext-install memcached \
-    && rm /tmp/memcached.tar.gz
+    curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/v3.0.3.tar.gz" && \
+    mkdir -p /usr/src/php/ext/memcached && \
+    tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 && \
+    docker-php-ext-configure memcached && \
+    docker-php-ext-install memcached && \
+    rm /tmp/memcached.tar.gz && \
 
 # Install php extension: OCI-8
-# RUN docker-php-ext-install -j$(nproc) oci8
+    # docker-php-ext-install -j$(nproc) oci8 && \
 
 # Enable Opcache
-RUN docker-php-ext-enable opcache
+    docker-php-ext-enable opcache && \
 
 # Install php extension: PDO
-RUN docker-php-ext-install -j$(nproc) pdo
+    docker-php-ext-install -j$(nproc) pdo && \
 
 # Install php extension: PDO: MSSQL/SYBASE
-RUN ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so && \
+    ln -s /usr/lib/x86_64-linux-gnu/libsybdb.so /usr/lib/libsybdb.so && \
     ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a /usr/lib/libsybdb.a && \
     ldconfig -v && \
-    docker-php-ext-install -j$(nproc) pdo_dblib
+    docker-php-ext-install -j$(nproc) pdo_dblib && \
 
 # Install php extension: PDO: MySQL
-RUN docker-php-ext-install -j$(nproc) pdo_mysql
+    docker-php-ext-install -j$(nproc) pdo_mysql && \
 
 # Install php extension: mysqli (used by the legacy system)
-RUN docker-php-ext-install mysqli
+    docker-php-ext-install mysqli && \
 
 # Install php extension: zip
-RUN docker-php-ext-install -j$(nproc) zip
+    docker-php-ext-install -j$(nproc) zip
 
 COPY resources/usr/local/etc/php/php.ini /usr/local/etc/php/
 


### PR DESCRIPTION
This combines the various `apt-get install` packages and organizes packages installed/configured via the docker-php-ext-* commands.

Installers are sorted alphabetically by which package they install.

This also updates the `memcached` package to use a PHP7 installer that is not in dev.