### PR TITLE
Look for databases and not tables when checking that mysql is up

### DIFF
--- a/php/resources/root/docker-entrypoint-snapshot.sh
+++ b/php/resources/root/docker-entrypoint-snapshot.sh
@@ -14,7 +14,7 @@ trap 'onTerminate' SIGTERM
 #
 
 # Wait for database to be started...
-until echo "show tables" | mysql -h db -u limsdbuser --password='limsdbpassword' limsdockerdb &> /dev/null
+until echo "show databases" | mysql -h db -u limsdbuser --password='limsdbpassword' limsdockerdb &> /dev/null
 do
     echo "Waiting for mysql..."
     sleep 2

--- a/php/resources/root/docker-entrypoint.sh
+++ b/php/resources/root/docker-entrypoint.sh
@@ -15,7 +15,7 @@ trap 'onTerminate' SIGTERM
 # Skip if mysql host isn't connected
 if host db ; then
     # Wait for database to be started...
-    until echo "show tables" | mysql -h db -u root --password='root' &> /dev/null
+    until echo "show databases" | mysql -h db -u root --password='root' &> /dev/null
     do
         echo "Waiting for mysql..."
         sleep 2


### PR DESCRIPTION
I kept getting the message that the php container was waiting for mysql, but the mysql container was up and running and I could manually connect to it.  The problem was that we were checking by looking for tables and Mariadb was complaining that not database was selected. So I'm switching this to look at the databases instead since that doesn't require a db being selected.