### PR TITLE
Upgrade httpd conf to Apache 2.4 with LIMS Customizations

### DIFF
--- a/php/resources/etc/httpd/conf/httpd.conf
+++ b/php/resources/etc/httpd/conf/httpd.conf
@@ -353,81 +353,81 @@ EnableSendfile on
 IncludeOptional conf.d/*.conf
 
 <VirtualHost *:80>
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	ServerName lims-web-docker-dev
+    # The ServerName directive sets the request scheme, hostname and port that
+    # the server uses to identify itself. This is used when creating
+    # redirection URLs. In the context of virtual hosts, the ServerName
+    # specifies what hostname must appear in the request's Host: header to
+    # match this virtual host. For the default virtual host (this file) this
+    # value is not decisive as it is used as a last resort host regardless.
+    # However, you must set it for any further virtual host explicitly.
+    ServerName lims-web-docker-dev
 
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
 
-	<Directory /var/www/html>
+    <Directory /var/www/html>
         Options Indexes FollowSymLinks
         AllowOverride All
     </Directory>
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
 
-	ErrorLog /etc/httpd/logs/error_log
-	CustomLog /etc/httpd/logs/access_log combined
+    ErrorLog /etc/httpd/logs/error_log
+    CustomLog /etc/httpd/logs/access_log combined
 
     # NOTE: duplicated in docker-compose.yml
-	PassEnv SYMFONY__secret
-	PassEnv SYMFONY__locale
-	PassEnv SYMFONY__debug_toolbar
-	PassEnv SYMFONY__debug_redirects
-	PassEnv SYMFONY__standalone_mode
-	PassEnv SYMFONY__database_host
-	PassEnv SYMFONY__database_driver
-	PassEnv SYMFONY__database_port
-	PassEnv SYMFONY__database_name
-	PassEnv SYMFONY__database_user
-	PassEnv SYMFONY__database_password
-	PassEnv SYMFONY__mailer_disable_delivery
-	PassEnv SYMFONY__mailer_transport
-	PassEnv SYMFONY__mailer_host
-	PassEnv SYMFONY__mailer_user
-	PassEnv SYMFONY__mailer_password
-	PassEnv SYMFONY__mailer_delivery_address
-	PassEnv SYMFONY__monolog_delivery_address
-	PassEnv SYMFONY__curl_request_timeout
-	PassEnv SYMFONY__relative_session_save_path
-	PassEnv SYMFONY__active_directory_enabled
-	PassEnv SYMFONY__active_directory_server
-	PassEnv SYMFONY__active_directory_username
-	PassEnv SYMFONY__active_directory_password
-	PassEnv SYMFONY__active_directory_base_dn
-	PassEnv SYMFONY__active_directory_account_suffix
-	PassEnv SYMFONY__authentication_enable_sso
-	PassEnv SYMFONY__authentication_sso_strip_username_suffix
-	PassEnv SYMFONY__zan__modules__datastoreRoot
-	PassEnv SYMFONY__zan__performance_log_destination
-	PassEnv SYMFONY__oracle_host
-	PassEnv SYMFONY__oracle_dbname
-	PassEnv SYMFONY__projects_drive_root_dir
+    PassEnv SYMFONY__secret
+    PassEnv SYMFONY__locale
+    PassEnv SYMFONY__debug_toolbar
+    PassEnv SYMFONY__debug_redirects
+    PassEnv SYMFONY__standalone_mode
+    PassEnv SYMFONY__database_host
+    PassEnv SYMFONY__database_driver
+    PassEnv SYMFONY__database_port
+    PassEnv SYMFONY__database_name
+    PassEnv SYMFONY__database_user
+    PassEnv SYMFONY__database_password
+    PassEnv SYMFONY__mailer_disable_delivery
+    PassEnv SYMFONY__mailer_transport
+    PassEnv SYMFONY__mailer_host
+    PassEnv SYMFONY__mailer_user
+    PassEnv SYMFONY__mailer_password
+    PassEnv SYMFONY__mailer_delivery_address
+    PassEnv SYMFONY__monolog_delivery_address
+    PassEnv SYMFONY__curl_request_timeout
+    PassEnv SYMFONY__relative_session_save_path
+    PassEnv SYMFONY__active_directory_enabled
+    PassEnv SYMFONY__active_directory_server
+    PassEnv SYMFONY__active_directory_username
+    PassEnv SYMFONY__active_directory_password
+    PassEnv SYMFONY__active_directory_base_dn
+    PassEnv SYMFONY__active_directory_account_suffix
+    PassEnv SYMFONY__authentication_enable_sso
+    PassEnv SYMFONY__authentication_sso_strip_username_suffix
+    PassEnv SYMFONY__zan__modules__datastoreRoot
+    PassEnv SYMFONY__zan__performance_log_destination
+    PassEnv SYMFONY__oracle_host
+    PassEnv SYMFONY__oracle_dbname
+    PassEnv SYMFONY__projects_drive_root_dir
 
-	PassEnv core_databaseConnections_default_host
-	PassEnv core_databaseConnections_default_username
-	PassEnv core_databaseConnections_default_password
-	PassEnv core_databaseConnections_default_database
-	PassEnv core_htmlRoot
-	PassEnv core_dataStoreRoot
-	PassEnv core_email_forceDestination
-	PassEnv core_smarty_writePath
-	PassEnv site_symfony_enabled
-	PassEnv site_symfony_root
-	PassEnv site_symfony_htmlRoot
-	PassEnv site_symfony_webRoot
-	PassEnv site_symfony_loginUrl
-	PassEnv site_symfony_moduleSearchPaths
+    PassEnv core_databaseConnections_default_host
+    PassEnv core_databaseConnections_default_username
+    PassEnv core_databaseConnections_default_password
+    PassEnv core_databaseConnections_default_database
+    PassEnv core_htmlRoot
+    PassEnv core_dataStoreRoot
+    PassEnv core_email_forceDestination
+    PassEnv core_smarty_writePath
+    PassEnv site_symfony_enabled
+    PassEnv site_symfony_root
+    PassEnv site_symfony_htmlRoot
+    PassEnv site_symfony_webRoot
+    PassEnv site_symfony_loginUrl
+    PassEnv site_symfony_moduleSearchPaths
 </VirtualHost>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/php/resources/etc/httpd/conf/httpd.conf
+++ b/php/resources/etc/httpd/conf/httpd.conf
@@ -1,136 +1,42 @@
 #
-# This is the main Apache server configuration file.  It contains the
+# This is the main Apache HTTP server configuration file.  It contains the
 # configuration directives that give the server its instructions.
-# See <URL:http://httpd.apache.org/docs/2.2/> for detailed information.
-# In particular, see
-# <URL:http://httpd.apache.org/docs/2.2/mod/directives.html>
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
 # for a discussion of each configuration directive.
-#
 #
 # Do NOT simply read the instructions in here without understanding
 # what they do.  They're here only as hints or reminders.  If you are unsure
 # consult the online docs. You have been warned.  
 #
-# The configuration directives are grouped into three basic sections:
-#  1. Directives that control the operation of the Apache server process as a
-#     whole (the 'global environment').
-#  2. Directives that define the parameters of the 'main' or 'default' server,
-#     which responds to requests that aren't handled by a virtual host.
-#     These directives also provide default values for the settings
-#     of all virtual hosts.
-#  3. Settings for virtual hosts, which allow Web requests to be sent to
-#     different IP addresses or hostnames and have them handled by the
-#     same Apache server process.
-#
 # Configuration and logfile names: If the filenames you specify for many
 # of the server's control files begin with "/" (or "drive:/" for Win32), the
 # server will use that explicit path.  If the filenames do *not* begin
-# with "/", the value of ServerRoot is prepended -- so "logs/foo.log"
-# with ServerRoot set to "/etc/httpd" will be interpreted by the
-# server as "/etc/httpd/logs/foo.log".
-#
-
-### Section 1: Global Environment
-#
-# The directives in this section affect the overall operation of Apache,
-# such as the number of concurrent requests it can handle or where it
-# can find its configuration files.
-#
-
-#
-# Don't give away too much information about all the subcomponents
-# we are running.  Comment out this line if you don't mind remote sites
-# finding out what major optional modules you are running
-ServerTokens OS
+# with "/", the value of ServerRoot is prepended -- so 'log/access_log'
+# with ServerRoot set to '/www' will be interpreted by the
+# server as '/www/log/access_log', where as '/log/access_log' will be
+# interpreted as '/log/access_log'.
 
 #
 # ServerRoot: The top of the directory tree under which the server's
 # configuration, error, and log files are kept.
 #
-# NOTE!  If you intend to place this on an NFS (or otherwise network)
-# mounted filesystem then please read the LockFile documentation
-# (available at <URL:http://httpd.apache.org/docs/2.2/mod/mpm_common.html#lockfile>);
-# you will save yourself a lot of trouble.
-#
-# Do NOT add a slash at the end of the directory path.
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
 #
 ServerRoot "/etc/httpd"
 
 #
-# PidFile: The file in which the server should record its process
-# identification number when it starts.  Note the PIDFILE variable in
-# /etc/sysconfig/httpd must be set appropriately if this location is
-# changed.
-#
-PidFile run/httpd.pid
-
-#
-# Timeout: The number of seconds before receives and sends time out.
-#
-Timeout 60
-
-#
-# KeepAlive: Whether or not to allow persistent connections (more than
-# one request per connection). Set to "Off" to deactivate.
-#
-KeepAlive Off
-
-#
-# MaxKeepAliveRequests: The maximum number of requests to allow
-# during a persistent connection. Set to 0 to allow an unlimited amount.
-# We recommend you leave this number high, for maximum performance.
-#
-MaxKeepAliveRequests 100
-
-#
-# KeepAliveTimeout: Number of seconds to wait for the next request from the
-# same client on the same connection.
-#
-KeepAliveTimeout 15
-
-##
-## Server-Pool Size Regulation (MPM specific)
-## 
-
-# prefork MPM
-# StartServers: number of server processes to start
-# MinSpareServers: minimum number of server processes which are kept spare
-# MaxSpareServers: maximum number of server processes which are kept spare
-# ServerLimit: maximum value for MaxClients for the lifetime of the server
-# MaxClients: maximum number of server processes allowed to start
-# MaxRequestsPerChild: maximum number of requests a server process serves
-<IfModule prefork.c>
-StartServers       8
-MinSpareServers    5
-MaxSpareServers   20
-ServerLimit      256
-MaxClients       256
-MaxRequestsPerChild  4000
-</IfModule>
-
-# worker MPM
-# StartServers: initial number of server processes to start
-# MaxClients: maximum number of simultaneous client connections
-# MinSpareThreads: minimum number of worker threads which are kept spare
-# MaxSpareThreads: maximum number of worker threads which are kept spare
-# ThreadsPerChild: constant number of worker threads in each server process
-# MaxRequestsPerChild: maximum number of requests a server process serves
-<IfModule worker.c>
-StartServers         4
-MaxClients         300
-MinSpareThreads     25
-MaxSpareThreads     75 
-ThreadsPerChild     25
-MaxRequestsPerChild  0
-</IfModule>
-
-#
 # Listen: Allows you to bind Apache to specific IP addresses and/or
-# ports, in addition to the default. See also the <VirtualHost>
+# ports, instead of the default. See also the <VirtualHost>
 # directive.
 #
 # Change this to Listen on specific IP addresses as shown below to 
-# prevent Apache from glomming onto all bound IP addresses (0.0.0.0)
+# prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
 Listen 80
@@ -147,102 +53,20 @@ Listen 80
 # Example:
 # LoadModule foo_module modules/mod_foo.so
 #
-LoadModule auth_basic_module modules/mod_auth_basic.so
-LoadModule auth_digest_module modules/mod_auth_digest.so
-LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_alias_module modules/mod_authn_alias.so
-LoadModule authn_anon_module modules/mod_authn_anon.so
-LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule authn_default_module modules/mod_authn_default.so
-LoadModule authz_host_module modules/mod_authz_host.so
-LoadModule authz_user_module modules/mod_authz_user.so
-LoadModule authz_owner_module modules/mod_authz_owner.so
-LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
-LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule authz_default_module modules/mod_authz_default.so
-LoadModule ldap_module modules/mod_ldap.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
-LoadModule include_module modules/mod_include.so
-LoadModule log_config_module modules/mod_log_config.so
-LoadModule logio_module modules/mod_logio.so
-LoadModule env_module modules/mod_env.so
-LoadModule ext_filter_module modules/mod_ext_filter.so
-LoadModule mime_magic_module modules/mod_mime_magic.so
-LoadModule expires_module modules/mod_expires.so
-LoadModule deflate_module modules/mod_deflate.so
-LoadModule headers_module modules/mod_headers.so
-LoadModule usertrack_module modules/mod_usertrack.so
-LoadModule setenvif_module modules/mod_setenvif.so
-LoadModule mime_module modules/mod_mime.so
-LoadModule dav_module modules/mod_dav.so
-LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
-LoadModule info_module modules/mod_info.so
-LoadModule dav_fs_module modules/mod_dav_fs.so
-LoadModule vhost_alias_module modules/mod_vhost_alias.so
-LoadModule negotiation_module modules/mod_negotiation.so
-LoadModule dir_module modules/mod_dir.so
-LoadModule actions_module modules/mod_actions.so
-LoadModule speling_module modules/mod_speling.so
-LoadModule userdir_module modules/mod_userdir.so
-LoadModule alias_module modules/mod_alias.so
-LoadModule substitute_module modules/mod_substitute.so
-LoadModule rewrite_module modules/mod_rewrite.so
-LoadModule proxy_module modules/mod_proxy.so
-LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
-LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-LoadModule proxy_http_module modules/mod_proxy_http.so
-LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
-LoadModule proxy_connect_module modules/mod_proxy_connect.so
-LoadModule cache_module modules/mod_cache.so
-LoadModule suexec_module modules/mod_suexec.so
-LoadModule disk_cache_module modules/mod_disk_cache.so
-LoadModule cgi_module modules/mod_cgi.so
-LoadModule version_module modules/mod_version.so
-
-#
-# The following modules are not loaded by default:
-#
-#LoadModule asis_module modules/mod_asis.so
-#LoadModule authn_dbd_module modules/mod_authn_dbd.so
-#LoadModule cern_meta_module modules/mod_cern_meta.so
-#LoadModule cgid_module modules/mod_cgid.so
-#LoadModule dbd_module modules/mod_dbd.so
-#LoadModule dumpio_module modules/mod_dumpio.so
-#LoadModule filter_module modules/mod_filter.so
-#LoadModule ident_module modules/mod_ident.so
-#LoadModule log_forensic_module modules/mod_log_forensic.so
-#LoadModule unique_id_module modules/mod_unique_id.so
-#
-
-#
-# Load config files from the config directory "/etc/httpd/conf.d".
-#
-Include conf.d/*.conf
-
-#
-# ExtendedStatus controls whether Apache will generate "full" status
-# information (ExtendedStatus On) or just basic information (ExtendedStatus
-# Off) when the "server-status" handler is called. The default is Off.
-#
-#ExtendedStatus On
+Include conf.modules.d/*.conf
 
 #
 # If you wish httpd to run as a different user or group, you must run
 # httpd as root initially and it will switch.  
 #
 # User/Group: The name (or #number) of the user/group to run httpd as.
-#  . On SCO (ODT 3) use "User nouser" and "Group nogroup".
-#  . On HPUX you may not be able to use shared memory as nobody, and the
-#    suggested workaround is to create a user www and use that user.
-#  NOTE that some kernels refuse to setgid(Group) or semctl(IPC_SET)
-#  when the value of (unsigned)Group is above 60000; 
-#  don't use Group #-1 on these systems!
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
 #
 User limsuser
 Group limsuser
 
-### Section 2: 'Main' server configuration
+# 'Main' server configuration
 #
 # The directives in this section set up the values used by the 'main'
 # server, which responds to any requests that aren't handled by a
@@ -266,42 +90,18 @@ ServerAdmin root@localhost
 # This can often be determined automatically, but we recommend you specify
 # it explicitly to prevent problems during startup.
 #
-# If this is not set to valid DNS name for your host, server-generated
-# redirections will not work.  See also the UseCanonicalName directive.
-#
 # If your host doesn't have a registered DNS name, enter its IP address here.
-# You will have to access it by its address anyway, and this will make 
-# redirections work in a sensible way.
 #
 #ServerName www.example.com:80
 
 #
-# UseCanonicalName: Determines how Apache constructs self-referencing 
-# URLs and the SERVER_NAME and SERVER_PORT variables.
-# When set "Off", Apache will use the Hostname and Port supplied
-# by the client.  When set "On", Apache will use the value of the
-# ServerName directive.
-#
-UseCanonicalName Off
-
-#
-# DocumentRoot: The directory out of which you will serve your
-# documents. By default, all requests are taken from this directory, but
-# symbolic links and aliases may be used to point to other locations.
-#
-DocumentRoot "/var/www/html"
-
-#
-# Each directory to which Apache has access can be configured with respect
-# to which services and features are allowed and/or disabled in that
-# directory (and its subdirectories). 
-#
-# First, we configure the "default" to be a very restrictive set of 
-# features.  
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
 #
 <Directory />
-    Options FollowSymLinks
-    AllowOverride None
+    AllowOverride none
+    Require all denied
 </Directory>
 
 #
@@ -312,167 +112,65 @@ DocumentRoot "/var/www/html"
 #
 
 #
-# This should be changed to whatever you set DocumentRoot to.
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
 #
-<Directory "/var/www/html">
+DocumentRoot "/var/www/html"
 
 #
-# Possible values for the Options directive are "None", "All",
-# or any combination of:
-#   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+# Relax access to content within /var/www.
 #
-# Note that "MultiViews" must be named *explicitly* --- "Options All"
-# doesn't give it to you.
-#
-# The Options directive is both complicated and important.  Please see
-# http://httpd.apache.org/docs/2.2/mod/core.html#options
-# for more information.
-#
-    Options Indexes FollowSymLinks
-
-#
-# AllowOverride controls what directives may be placed in .htaccess files.
-# It can be "All", "None", or any combination of the keywords:
-#   Options FileInfo AuthConfig Limit
-#
+<Directory "/var/www">
     AllowOverride None
-
-#
-# Controls who can get stuff from this server.
-#
-    Order allow,deny
-    Allow from all
-
+    # Allow open access:
+    Require all granted
 </Directory>
 
-#
-# UserDir: The name of the directory that is appended onto a user's home
-# directory if a ~user request is received.
-#
-# The path to the end user account 'public_html' directory must be
-# accessible to the webserver userid.  This usually means that ~userid
-# must have permissions of 711, ~userid/public_html must have permissions
-# of 755, and documents contained therein must be world-readable.
-# Otherwise, the client will only receive a "403 Forbidden" message.
-#
-# See also: http://httpd.apache.org/docs/misc/FAQ.html#forbidden
-#
-<IfModule mod_userdir.c>
+# Further relax access to the default document root:
+<Directory "/var/www/html">
     #
-    # UserDir is disabled by default since it can confirm the presence
-    # of a username on the system (depending on home directory
-    # permissions).
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
     #
-    UserDir disabled
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
 
     #
-    # To enable requests to /~user/ to serve the user's public_html
-    # directory, remove the "UserDir disabled" line above, and uncomment
-    # the following line instead:
-    # 
-    #UserDir public_html
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   Options FileInfo AuthConfig Limit
+    #
+    AllowOverride None
 
-</IfModule>
-
-#
-# Control access to UserDir directories.  The following is an example
-# for a site where these directories are restricted to read-only.
-#
-#<Directory /home/*/public_html>
-#    AllowOverride FileInfo AuthConfig Limit
-#    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
-#    <Limit GET POST OPTIONS>
-#        Order allow,deny
-#        Allow from all
-#    </Limit>
-#    <LimitExcept GET POST OPTIONS>
-#        Order deny,allow
-#        Deny from all
-#    </LimitExcept>
-#</Directory>
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
 
 #
 # DirectoryIndex: sets the file that Apache will serve if a directory
 # is requested.
 #
-# The index.html.var file (a type-map) is used to deliver content-
-# negotiated documents.  The MultiViews Option can be used for the 
-# same purpose, but it is much slower.
-#
-DirectoryIndex index.html index.html.var
-
-#
-# AccessFileName: The name of the file to look for in each directory
-# for additional configuration directives.  See also the AllowOverride
-# directive.
-#
-AccessFileName .htaccess
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
 
 #
 # The following lines prevent .htaccess and .htpasswd files from being 
 # viewed by Web clients. 
 #
-<Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
-    Satisfy All
+<Files ".ht*">
+    Require all denied
 </Files>
-
-#
-# TypesConfig describes where the mime.types file (or equivalent) is
-# to be found.
-#
-TypesConfig /etc/mime.types
-
-#
-# DefaultType is the default MIME type the server will use for a document
-# if it cannot otherwise determine one, such as from filename extensions.
-# If your server contains mostly text or HTML documents, "text/plain" is
-# a good value.  If most of your content is binary, such as applications
-# or images, you may want to use "application/octet-stream" instead to
-# keep browsers from trying to display binary files as though they are
-# text.
-#
-DefaultType text/plain
-
-#
-# The mod_mime_magic module allows the server to use various hints from the
-# contents of the file itself to determine its type.  The MIMEMagicFile
-# directive tells the module where the hint definitions are located.
-#
-<IfModule mod_mime_magic.c>
-#   MIMEMagicFile /usr/share/magic.mime
-    MIMEMagicFile conf/magic
-</IfModule>
-
-#
-# HostnameLookups: Log the names of clients or just their IP addresses
-# e.g., www.apache.org (on) or 204.62.129.132 (off).
-# The default is off because it'd be overall better for the net if people
-# had to knowingly turn this feature on, since enabling it means that
-# each client request will result in AT LEAST one lookup request to the
-# nameserver.
-#
-HostnameLookups Off
-
-#
-# EnableMMAP: Control whether memory-mapping is used to deliver
-# files (assuming that the underlying OS supports it).
-# The default is on; turn this off if you serve from NFS-mounted 
-# filesystems.  On some systems, turning it off (regardless of
-# filesystem) can improve performance; for details, please see
-# http://httpd.apache.org/docs/2.2/mod/core.html#enablemmap
-#
-#EnableMMAP off
-
-#
-# EnableSendfile: Control whether the sendfile kernel support is 
-# used to deliver files (assuming that the OS supports it). 
-# The default is on; turn this off if you serve from NFS-mounted 
-# filesystems.  Please see
-# http://httpd.apache.org/docs/2.2/mod/core.html#enablesendfile
-#
-#EnableSendfile off
 
 #
 # ErrorLog: The location of the error log file.
@@ -481,7 +179,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog logs/error_log
+ErrorLog "logs/error_log"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -490,90 +188,65 @@ ErrorLog logs/error_log
 #
 LogLevel warn
 
-#
-# The following directives define some format nicknames for use with
-# a CustomLog directive (see below).
-#
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%h %l %u %t \"%r\" %>s %b" common
-LogFormat "%{Referer}i -> %U" referer
-LogFormat "%{User-agent}i" agent
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
 
-# "combinedio" includes actual counts of actual bytes received (%I) and sent (%O); this
-# requires the mod_logio module to be loaded.
-#LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
 
-#
-# The location and format of the access logfile (Common Logfile Format).
-# If you do not define any access logfiles within a <VirtualHost>
-# container, they will be logged here.  Contrariwise, if you *do*
-# define per-<VirtualHost> access logfiles, transactions will be
-# logged therein and *not* in this file.
-#
-#CustomLog logs/access_log common
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    #CustomLog "logs/access_log" common
 
-#
-# If you would like to have separate agent and referer logfiles, uncomment
-# the following directives.
-#
-#CustomLog logs/referer_log referer
-#CustomLog logs/agent_log agent
-
-#
-# For a single logfile with access, agent, and referer information
-# (Combined Logfile Format), use the following directive:
-#
-CustomLog logs/access_log combined
-
-#
-# Optionally add a line containing the server version and virtual host
-# name to server-generated pages (internal error documents, FTP directory
-# listings, mod_status and mod_info output etc., but not CGI generated
-# documents or custom error documents).
-# Set to "EMail" to also include a mailto: link to the ServerAdmin.
-# Set to one of:  On | Off | EMail
-#
-ServerSignature On
-
-#
-# Aliases: Add here as many aliases as you need (with no limit). The format is 
-# Alias fakename realname
-#
-# Note that if you include a trailing / on fakename then the server will
-# require it to be present in the URL.  So "/icons" isn't aliased in this
-# example, only "/icons/".  If the fakename is slash-terminated, then the 
-# realname must also be slash terminated, and if the fakename omits the 
-# trailing slash, the realname must also omit it.
-#
-# We include the /icons/ alias for FancyIndexed directory listings.  If you
-# do not use FancyIndexing, you may comment this out.
-#
-Alias /icons/ "/var/www/icons/"
-
-<Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
-    AllowOverride None
-    Order allow,deny
-    Allow from all
-</Directory>
-
-#
-# WebDAV module configuration section.
-# 
-<IfModule mod_dav_fs.c>
-    # Location of the WebDAV lock database.
-    DAVLockDB /var/lib/dav/lockdb
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    CustomLog "logs/access_log" combined
 </IfModule>
 
-#
-# ScriptAlias: This controls which directories contain server scripts.
-# ScriptAliases are essentially the same as Aliases, except that
-# documents in the realname directory are treated as applications and
-# run by the server when requested rather than as documents sent to the client.
-# The same rules about trailing "/" apply to ScriptAlias directives as to
-# Alias.
-#
-ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+
+</IfModule>
 
 #
 # "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
@@ -582,172 +255,56 @@ ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
 <Directory "/var/www/cgi-bin">
     AllowOverride None
     Options None
-    Order allow,deny
-    Allow from all
+    Require all granted
 </Directory>
 
-#
-# Redirect allows you to tell clients about documents which used to exist in
-# your server's namespace, but do not anymore. This allows you to tell the
-# clients where to look for the relocated document.
-# Example:
-# Redirect permanent /foo http://www.example.com/bar
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig /etc/mime.types
 
-#
-# Directives controlling the display of server-generated directory listings.
-#
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
 
-#
-# IndexOptions: Controls the appearance of server-generated directory
-# listings.
-#
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
 
-#
-# AddIcon* directives tell the server which icon to show for different
-# files or filename extensions.  These are only displayed for
-# FancyIndexed directories.
-#
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
 
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
-
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif /core
-
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
-
-#
-# DefaultIcon is which icon to show for files which do not have an icon
-# explicitly set.
-#
-DefaultIcon /icons/unknown.gif
-
-#
-# AddDescription allows you to place a short description after a file in
-# server-generated indexes.  These are only displayed for FancyIndexed
-# directories.
-# Format: AddDescription "description" filename
-#
-#AddDescription "GZIP compressed document" .gz
-#AddDescription "tar archive" .tar
-#AddDescription "GZIP compressed tar archive" .tgz
-
-#
-# ReadmeName is the name of the README file the server will look for by
-# default, and append to directory listings.
-#
-# HeaderName is the name of a file which should be prepended to
-# directory indexes. 
-ReadmeName README.html
-HeaderName HEADER.html
-
-#
-# IndexIgnore is a set of filenames which directory indexing should ignore
-# and not include in the listing.  Shell-style wildcarding is permitted.
-#
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
-
-#
-# DefaultLanguage and AddLanguage allows you to specify the language of 
-# a document. You can then use content negotiation to give a browser a 
-# file in a language the user can understand.
-#
-# Specify a default language. This means that all data
-# going out without a specific language tag (see below) will 
-# be marked with this one. You probably do NOT want to set
-# this unless you are sure it is correct for all cases.
-#
-# * It is generally better to not mark a page as 
-# * being a certain language than marking it with the wrong
-# * language!
-#
-# DefaultLanguage nl
-#
-# Note 1: The suffix does not have to be the same as the language
-# keyword --- those with documents in Polish (whose net-standard
-# language code is pl) may wish to use "AddLanguage pl .po" to
-# avoid the ambiguity with the common suffix for perl scripts.
-#
-# Note 2: The example entries below illustrate that in some cases 
-# the two character 'Language' abbreviation is not identical to 
-# the two character 'Country' code for its country,
-# E.g. 'Danmark/dk' versus 'Danish/da'.
-#
-# Note 3: In the case of 'ltz' we violate the RFC by using a three char
-# specifier. There is 'work in progress' to fix this and get
-# the reference data for rfc1766 cleaned up.
-#
-# Catalan (ca) - Croatian (hr) - Czech (cs) - Danish (da) - Dutch (nl)
-# English (en) - Esperanto (eo) - Estonian (et) - French (fr) - German (de)
-# Greek-Modern (el) - Hebrew (he) - Italian (it) - Japanese (ja)
-# Korean (ko) - Luxembourgeois* (ltz) - Norwegian Nynorsk (nn)
-# Norwegian (no) - Polish (pl) - Portugese (pt)
-# Brazilian Portuguese (pt-BR) - Russian (ru) - Swedish (sv)
-# Simplified Chinese (zh-CN) - Spanish (es) - Traditional Chinese (zh-TW)
-#
-AddLanguage ca .ca
-AddLanguage cs .cz .cs
-AddLanguage da .dk
-AddLanguage de .de
-AddLanguage el .el
-AddLanguage en .en
-AddLanguage eo .eo
-AddLanguage es .es
-AddLanguage et .et
-AddLanguage fr .fr
-AddLanguage he .he
-AddLanguage hr .hr
-AddLanguage it .it
-AddLanguage ja .ja
-AddLanguage ko .ko
-AddLanguage ltz .ltz
-AddLanguage nl .nl
-AddLanguage nn .nn
-AddLanguage no .no
-AddLanguage pl .po
-AddLanguage pt .pt
-AddLanguage pt-BR .pt-br
-AddLanguage ru .ru
-AddLanguage sv .sv
-AddLanguage zh-CN .zh-cn
-AddLanguage zh-TW .zh-tw
-
-#
-# LanguagePriority allows you to give precedence to some languages
-# in case of a tie during content negotiation.
-#
-# Just list the languages in decreasing order of preference. We have
-# more or less alphabetized them here. You probably want to change this.
-#
-LanguagePriority en ca cs da de el eo es et fr he hr it ja ko ltz nl nn no pl pt pt-BR ru sv zh-CN zh-TW
-
-#
-# ForceLanguagePriority allows you to serve a result page rather than
-# MULTIPLE CHOICES (Prefer) [in case of a tie] or NOT ACCEPTABLE (Fallback)
-# [in case no accepted languages matched the available variants]
-#
-ForceLanguagePriority Prefer Fallback
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    AddType text/html .shtml
+    AddOutputFilter INCLUDES .shtml
+</IfModule>
 
 #
 # Specify a default charset for all content served; this enables
@@ -758,71 +315,14 @@ ForceLanguagePriority Prefer Fallback
 #
 AddDefaultCharset UTF-8
 
-#
-# AddType allows you to add to or override the MIME configuration
-# file mime.types for specific file types.
-#
-#AddType application/x-tar .tgz
-
-#
-# AddEncoding allows you to have certain browsers uncompress
-# information on the fly. Note: Not all browsers support this.
-# Despite the name similarity, the following Add* directives have nothing
-# to do with the FancyIndexing customization directives above.
-#
-#AddEncoding x-compress .Z
-#AddEncoding x-gzip .gz .tgz
-
-# If the AddEncoding directives above are commented-out, then you
-# probably should define those extensions to indicate media types:
-#
-AddType application/x-compress .Z
-AddType application/x-gzip .gz .tgz
-
-#
-#   MIME-types for downloading Certificates and CRLs
-#
-AddType application/x-x509-ca-cert .crt
-AddType application/x-pkcs7-crl    .crl
-
-#
-# AddHandler allows you to map certain file extensions to "handlers":
-# actions unrelated to filetype. These can be either built into the server
-# or added with the Action directive (see below)
-#
-# To use CGI scripts outside of ScriptAliased directories:
-# (You will also need to add "ExecCGI" to the "Options" directive.)
-#
-#AddHandler cgi-script .cgi
-
-#
-# For files that include their own HTTP headers:
-#
-#AddHandler send-as-is asis
-
-#
-# For type maps (negotiated resources):
-# (This is enabled by default to allow the Apache "It Worked" page
-#  to be distributed in multiple languages.)
-#
-AddHandler type-map var
-
-#
-# Filters allow you to process content before it is sent to the client.
-#
-# To parse .shtml files for server-side includes (SSI):
-# (You will also need to add "Includes" to the "Options" directive.)
-#
-AddType text/html .shtml
-AddOutputFilter INCLUDES .shtml
-
-#
-# Action lets you define media types that will execute a script whenever
-# a matching file is called. This eliminates the need for repeated URL
-# pathnames for oft-used CGI file processors.
-# Format: Action media/type /cgi-script/location
-# Format: Action handler-name /cgi-script/location
-#
+<IfModule mime_magic_module>
+    #
+    # The mod_mime_magic module allows the server to use various hints from the
+    # contents of the file itself to determine its type.  The MIMEMagicFile
+    # directive tells the module where the hint definitions are located.
+    #
+    MIMEMagicFile conf/magic
+</IfModule>
 
 #
 # Customizable error responses come in three flavors:
@@ -836,177 +336,21 @@ AddOutputFilter INCLUDES .shtml
 #
 
 #
-# Putting this all together, we can internationalize error responses.
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults if commented: EnableMMAP On, EnableSendfile Off
 #
-# We use Alias to redirect any /error/HTTP_<error>.html.var response to
-# our collection of by-error message multi-language collections.  We use 
-# includes to substitute the appropriate text.
-#
-# You can modify the messages' appearance without changing any of the
-# default HTTP_<error>.html.var files by adding the line:
-#
-#   Alias /error/include/ "/your/include/path/"
-#
-# which allows you to create your own set of files by starting with the
-# /var/www/error/include/ files and
-# copying them to /your/include/path/, even on a per-VirtualHost basis.
-#
+#EnableMMAP off
+EnableSendfile on
 
-Alias /error/ "/var/www/error/"
-
-<IfModule mod_negotiation.c>
-<IfModule mod_include.c>
-    <Directory "/var/www/error">
-        AllowOverride None
-        Options IncludesNoExec
-        AddOutputFilter Includes html
-        AddHandler type-map var
-        Order allow,deny
-        Allow from all
-        LanguagePriority en es de fr
-        ForceLanguagePriority Prefer Fallback
-    </Directory>
-
-#    ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
-#    ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
-#    ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
-#    ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
-#    ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
-#    ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
-#    ErrorDocument 410 /error/HTTP_GONE.html.var
-#    ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
-#    ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
-#    ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
-#    ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
-#    ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
-#    ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
-#    ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
-#    ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
-#    ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
-#    ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
-
-</IfModule>
-</IfModule>
-
+# Supplemental configuration
 #
-# The following directives modify normal HTTP response behavior to
-# handle known problems with browser implementations.
-#
-BrowserMatch "Mozilla/2" nokeepalive
-BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
-BrowserMatch "RealPlayer 4\.0" force-response-1.0
-BrowserMatch "Java/1\.0" force-response-1.0
-BrowserMatch "JDK/1\.0" force-response-1.0
-
-#
-# The following directive disables redirects on non-GET requests for
-# a directory that does not include the trailing slash.  This fixes a 
-# problem with Microsoft WebFolders which does not appropriately handle 
-# redirects for folders with DAV methods.
-# Same deal with Apple's DAV filesystem and Gnome VFS support for DAV.
-#
-BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
-BrowserMatch "MS FrontPage" redirect-carefully
-BrowserMatch "^WebDrive" redirect-carefully
-BrowserMatch "^WebDAVFS/1.[0123]" redirect-carefully
-BrowserMatch "^gnome-vfs/1.0" redirect-carefully
-BrowserMatch "^XML Spy" redirect-carefully
-BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
-
-#
-# Allow server status reports generated by mod_status,
-# with the URL of http://servername/server-status
-# Change the ".example.com" to match your domain to enable.
-#
-#<Location /server-status>
-#    SetHandler server-status
-#    Order deny,allow
-#    Deny from all
-#    Allow from .example.com
-#</Location>
-
-#
-# Allow remote server configuration reports, with the URL of
-#  http://servername/server-info (requires that mod_info.c be loaded).
-# Change the ".example.com" to match your domain to enable.
-#
-#<Location /server-info>
-#    SetHandler server-info
-#    Order deny,allow
-#    Deny from all
-#    Allow from .example.com
-#</Location>
-
-#
-# Proxy Server directives. Uncomment the following lines to
-# enable the proxy server:
-#
-#<IfModule mod_proxy.c>
-#ProxyRequests On
-#
-#<Proxy *>
-#    Order deny,allow
-#    Deny from all
-#    Allow from .example.com
-#</Proxy>
-
-#
-# Enable/disable the handling of HTTP/1.1 "Via:" headers.
-# ("Full" adds the server version; "Block" removes all outgoing Via: headers)
-# Set to one of: Off | On | Full | Block
-#
-#ProxyVia On
-
-#
-# To enable a cache of proxied content, uncomment the following lines.
-# See http://httpd.apache.org/docs/2.2/mod/mod_cache.html for more details.
-#
-#<IfModule mod_disk_cache.c>
-#   CacheEnable disk /
-#   CacheRoot "/var/cache/mod_proxy"
-#</IfModule>
-#
-
-#</IfModule>
-# End of proxy directives.
-
-### Section 3: Virtual Hosts
-#
-# VirtualHost: If you want to maintain multiple domains/hostnames on your
-# machine you can setup VirtualHost containers for them. Most configurations
-# use only name-based virtual hosts so the server doesn't need to worry about
-# IP addresses. This is indicated by the asterisks in the directives below.
-#
-# Please see the documentation at 
-# <URL:http://httpd.apache.org/docs/2.2/vhosts/>
-# for further details before you try to setup virtual hosts.
-#
-# You may use the command line option '-S' to verify your virtual host
-# configuration.
-
-#
-# Use name-based virtual hosting.
-#
-#NameVirtualHost *:80
-#
-# NOTE: NameVirtualHost cannot be used without a port specifier 
-# (e.g. :80) if mod_ssl is being used, due to the nature of the
-# SSL protocol.
-#
-
-#
-# VirtualHost example:
-# Almost any Apache directive may go into a VirtualHost container.
-# The first VirtualHost section is used for requests without a known
-# server name.
-#
-#<VirtualHost *:80>
-#    ServerAdmin webmaster@dummy-host.example.com
-#    DocumentRoot /www/docs/dummy-host.example.com
-#    ServerName dummy-host.example.com
-#    ErrorLog logs/dummy-host.example.com-error_log
-#    CustomLog logs/dummy-host.example.com-access_log common
-#</VirtualHost>
+# Load config files in the "/etc/httpd/conf.d" directory, if any.
+IncludeOptional conf.d/*.conf
 
 <VirtualHost *:80>
 	# The ServerName directive sets the request scheme, hostname and port that


### PR DESCRIPTION
The base image used by this project was upgraded from CentOS 6 to CentOS 7. Apache 2.2 is out and Apache 2.4 is in. The old httpd conf file was the default conf file with just a handful of LIMS customizations. This new conf file is the same customizations on top of the default Apache 2.4 conf file.

Our customizations were using tabs whereas the rest of the file was using spaces. This corrects that, too.